### PR TITLE
feat: edição de temporadas e episódios por temporada

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 /.idea
+/docs

--- a/app/Http/Controllers/SeasonsController.php
+++ b/app/Http/Controllers/SeasonsController.php
@@ -2,11 +2,20 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\SyncSeasonsRequest;
 use App\Models\Series;
+use App\Services\SeriesService;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
 
 class SeasonsController extends Controller
 {
+    public function __construct(
+        private readonly SeriesService $seriesService,
+    ) {
+        //
+    }
+
     public function index(Series $series): View
     {
         $this->authorize('view', $series);
@@ -20,5 +29,16 @@ class SeasonsController extends Controller
             'series' => $series,
             'seasons' => $seasons,
         ]);
+    }
+
+    public function sync(SyncSeasonsRequest $request, Series $series): RedirectResponse
+    {
+        $this->authorize('update', $series);
+
+        $this->seriesService->syncSeasons($series, $request->validated()['seasons']);
+
+        return redirect()
+            ->route('series.edit', $series)
+            ->with('status', 'Temporadas atualizadas com sucesso!');
     }
 }

--- a/app/Http/Controllers/SeriesController.php
+++ b/app/Http/Controllers/SeriesController.php
@@ -71,6 +71,10 @@ class SeriesController extends Controller
     {
         $this->authorize('update', $series);
 
+        $series->load(['seasons' => function ($q) {
+            $q->withCount('episodes')->orderBy('number');
+        }]);
+
         return view('series.edit', [
             'series' => $series,
             'streamingServices' => StreamingService::orderBy('name')->get(),

--- a/app/Http/Requests/StoreSeriesRequest.php
+++ b/app/Http/Requests/StoreSeriesRequest.php
@@ -49,7 +49,7 @@ class StoreSeriesRequest extends FormRequest
             'year' => 'ano',
             'imdb_id' => 'ID do IMDB',
             'qt_seasons' => 'quantidade de temporadas',
-            'qt_episodes' => 'episódios por temporada',
+            'qt_episodes' => 'média de episódios por temporada',
             'cover_file' => 'capa',
             'cover_url' => 'URL da capa',
         ];

--- a/app/Http/Requests/SyncSeasonsRequest.php
+++ b/app/Http/Requests/SyncSeasonsRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SyncSeasonsRequest extends FormRequest
+{
+    protected $errorBag = 'seasons';
+
+    public function authorize(): bool
+    {
+        $series = $this->route('series');
+
+        return $this->user() && $series && $this->user()->can('update', $series);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'seasons' => ['required', 'array', 'min:1'],
+            'seasons.*.id' => ['nullable', 'integer'],
+            'seasons.*.episodes' => ['required', 'integer', 'min:1', 'max:500'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'seasons.required' => 'Informe pelo menos 1 temporada.',
+            'seasons.min' => 'Informe pelo menos 1 temporada.',
+            'seasons.*.episodes.required' => 'Informe a quantidade de episódios da temporada.',
+            'seasons.*.episodes.min' => 'Cada temporada precisa ter pelo menos 1 episódio.',
+            'seasons.*.episodes.max' => 'Uma temporada pode ter no máximo 500 episódios.',
+        ];
+    }
+}

--- a/app/Services/SeriesService.php
+++ b/app/Services/SeriesService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\Season;
 use App\Models\Series;
 use App\Models\User;
 use Illuminate\Http\UploadedFile;
@@ -129,5 +130,86 @@ class SeriesService
             $this->imageService->delete($series->cover_path);
             $series->delete();
         });
+    }
+
+    /**
+     * Reconcile the seasons (and their episode counts) of a series.
+     *
+     * Existing seasons are matched by id; missing ones are deleted, new ones
+     * (without id) are created. Seasons are renumbered sequentially (1..N).
+     * Episode counts grow by appending new episodes and shrink by removing the
+     * highest-numbered ones (even when watched).
+     *
+     * @param  array<int, array{id?: int|null, episodes: int}>  $seasons
+     */
+    public function syncSeasons(Series $series, array $seasons): void
+    {
+        DB::transaction(function () use ($series, $seasons) {
+            $existing = $series->seasons()->get()->keyBy('id');
+
+            $keptIds = collect($seasons)
+                ->pluck('id')
+                ->filter()
+                ->map(fn ($id) => (int) $id)
+                ->all();
+
+            $series->seasons()
+                ->whereNotIn('id', $keptIds)
+                ->get()
+                ->each(fn (Season $season) => $season->delete());
+
+            $number = 0;
+            foreach ($seasons as $row) {
+                $number++;
+                $episodes = max(1, (int) ($row['episodes'] ?? 1));
+                $id = ! empty($row['id']) ? (int) $row['id'] : null;
+
+                $season = $id ? $existing->get($id) : null;
+
+                if ($season === null) {
+                    $season = $series->seasons()->create(['number' => $number]);
+                    $this->adjustEpisodeCount($season, 0, $episodes);
+
+                    continue;
+                }
+
+                if ($season->number !== $number) {
+                    $season->update(['number' => $number]);
+                }
+
+                $current = $season->episodes()->count();
+                $this->adjustEpisodeCount($season, $current, $episodes);
+            }
+        });
+    }
+
+    private function adjustEpisodeCount(Season $season, int $current, int $target): void
+    {
+        if ($target > $current) {
+            $maxNumber = (int) ($season->episodes()->max('number') ?? 0);
+
+            $episodes = [];
+            for ($e = $maxNumber + 1; $e <= $maxNumber + ($target - $current); $e++) {
+                $episodes[] = [
+                    'season_id' => $season->id,
+                    'number' => $e,
+                    'watched' => false,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ];
+            }
+            $season->episodes()->insert($episodes);
+
+            return;
+        }
+
+        if ($target < $current) {
+            $idsToRemove = $season->episodes()
+                ->orderByDesc('number')
+                ->limit($current - $target)
+                ->pluck('id');
+
+            $season->episodes()->whereIn('id', $idsToRemove)->delete();
+        }
     }
 }

--- a/docs/context-geral.md
+++ b/docs/context-geral.md
@@ -94,7 +94,7 @@ Drivers padrão: **sessão, cache e fila no banco de dados** (tabelas criadas pe
 
 | Service | Função |
 |---------|--------|
-| `SeriesService` | Cria série dentro de transação, gerando N temporadas × M episódios; trata capa (upload/URL); atualiza e deleta (removendo a capa do storage). |
+| `SeriesService` | Cria série dentro de transação, gerando N temporadas × M episódios (M é apenas a média informada no cadastro); trata capa (upload/URL); atualiza e deleta (removendo a capa do storage). `syncSeasons()`: reconcilia as temporadas na edição — cria/remove temporadas, renumera em sequência e ajusta a quantidade de episódios de cada uma (ao diminuir, remove os de número mais alto). |
 | `EpisodeService` | `syncWatched()`: marca em massa os episódios de uma temporada como assistidos/não-assistidos a partir de uma lista de IDs (numa transação). |
 | `DashboardService` | `statsFor()`: agrega totais, separa séries em progresso/concluídas, calcula "continue assistindo" (próximo episódio não assistido) e atividade recente (últimos episódios marcados). |
 | `TopicService` | Lista tópicos paginados com filtros (`series_id`, ordenação por recentes/mais comentados) e cria tópicos. |
@@ -114,6 +114,7 @@ Drivers padrão: **sessão, cache e fila no banco de dados** (tabelas criadas pe
 | GET | `/series/omdb/search` | Busca OMDB (JSON) para autocompletar |
 | resource | `/series` (exceto `show`) | CRUD de séries |
 | GET | `/series/{series}/seasons` | Lista temporadas |
+| PUT | `/series/{series}/seasons` | Sincroniza temporadas/episódios (edição) |
 | GET | `/seasons/{season}/episodes` | Lista episódios |
 | POST | `/seasons/{season}/episodes` | Atualiza episódios assistidos |
 | GET/resource | `/community`, `/community/topics` | Fórum: lista/cria/mostra tópicos |
@@ -195,7 +196,7 @@ tests/                      # Feature/ (Pest) + Unit/
 
 ## 12. Fluxos de uso (resumo)
 
-1. **Cadastrar série** → escolhe streaming, informa nº de temporadas/episódios → o `SeriesService` cria tudo numa transação → capa via OMDB/upload/URL.
+1. **Cadastrar série** → escolhe streaming, informa nº de temporadas e a **média** de episódios por temporada → o `SeriesService` cria tudo numa transação → capa via OMDB/upload/URL. As temporadas e a quantidade de episódios de cada uma podem ser ajustadas depois na **edição da série** (seção "Temporadas").
 2. **Assistir** → abre temporada → marca episódios → `EpisodeService.syncWatched` atualiza em massa → progresso recalculado.
 3. **Acompanhar** → `Dashboard` mostra progresso, "continue assistindo" (próximo episódio) e atividade recente.
 4. **Comunidade** → cria tópico (opcionalmente ligado a uma série) → outros comentam/respondem (1 nível).

--- a/resources/views/series/create.blade.php
+++ b/resources/views/series/create.blade.php
@@ -76,8 +76,9 @@
                 </div>
 
                 <div>
-                    <x-input-label for="qt_episodes" :value="'Episódios por temporada'" />
+                    <x-input-label for="qt_episodes" :value="'Média de episódios por temporada'" />
                     <x-text-input id="qt_episodes" name="qt_episodes" type="number" min="1" max="500" class="mt-1 block w-full" :value="old('qt_episodes', 10)" required />
+                    <p class="mt-1 text-xs text-slate-500">Aplicado a todas as temporadas. Você pode ajustar cada temporada depois, ao editar a série.</p>
                     <x-input-error :messages="$errors->get('qt_episodes')" class="mt-1" />
                 </div>
 

--- a/resources/views/series/edit.blade.php
+++ b/resources/views/series/edit.blade.php
@@ -59,5 +59,70 @@
                 <x-gradient-button>Salvar</x-gradient-button>
             </div>
         </form>
+
+        <form action="{{ route('seasons.sync', $series) }}" method="POST"
+              x-data="seasonsManager({{ $series->seasons->map(fn ($s) => ['id' => $s->id, 'episodes' => $s->episodes_count])->values()->toJson() }})"
+              class="mt-6 bg-white rounded-xl border border-slate-200 shadow-sm p-6 space-y-4">
+            @csrf @method('PUT')
+
+            <div>
+                <h2 class="text-lg font-bold text-slate-900">Temporadas</h2>
+                <p class="text-sm text-slate-500">Adicione ou remova temporadas e ajuste quantos episódios cada uma tem. Ao diminuir, os episódios de número mais alto são removidos.</p>
+            </div>
+
+            @if ($errors->seasons->any())
+                <div class="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                    <ul class="list-disc list-inside space-y-1">
+                        @foreach ($errors->seasons->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
+            <div class="space-y-2">
+                <template x-for="(season, index) in seasons" :key="index">
+                    <div class="flex items-center gap-3 rounded-lg border border-slate-200 p-3">
+                        <input type="hidden" :name="`seasons[${index}][id]`" :value="season.id">
+                        <span class="font-semibold text-slate-700 w-28">Temporada <span x-text="index + 1"></span></span>
+                        <div class="flex-1">
+                            <label class="block text-xs text-slate-500 mb-1">Episódios</label>
+                            <input type="number" min="1" max="500" x-model.number="season.episodes"
+                                   :name="`seasons[${index}][episodes]`"
+                                   class="block w-full rounded-lg border-slate-300 focus:border-brand-blue focus:ring-brand-blue">
+                        </div>
+                        <button type="button" @click="remove(index)" x-show="seasons.length > 1"
+                                class="self-end rounded-lg border border-red-200 px-3 py-2 text-sm font-semibold text-red-600 hover:bg-red-50">
+                            Remover
+                        </button>
+                    </div>
+                </template>
+            </div>
+
+            <div class="flex items-center justify-between gap-3 pt-4 border-t border-slate-100">
+                <button type="button" @click="add()"
+                        class="rounded-lg border border-brand-mid/30 px-4 py-2 text-sm font-semibold text-brand-mid hover:bg-brand-gradient-soft">
+                    + Adicionar temporada
+                </button>
+                <x-gradient-button>Salvar temporadas</x-gradient-button>
+            </div>
+        </form>
     </div>
+
+    <script>
+        function seasonsManager(initial) {
+            return {
+                seasons: initial.length ? initial : [{ id: null, episodes: 10 }],
+                add() {
+                    this.seasons.push({ id: null, episodes: 10 });
+                },
+                remove(index) {
+                    if (! confirm(`Remover a Temporada ${index + 1}? Todos os episódios dela serão excluídos ao salvar.`)) {
+                        return;
+                    }
+                    this.seasons.splice(index, 1);
+                },
+            }
+        }
+    </script>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,7 @@ Route::middleware('auth')->group(function () {
 
     // Seasons & Episodes
     Route::get('/series/{series}/seasons', [SeasonsController::class, 'index'])->name('seasons.index');
+    Route::put('/series/{series}/seasons', [SeasonsController::class, 'sync'])->name('seasons.sync');
     Route::get('/seasons/{season}/episodes', [EpisodesController::class, 'index'])->name('episodes.index');
     Route::post('/seasons/{season}/episodes', [EpisodesController::class, 'update'])->name('episodes.update');
 


### PR DESCRIPTION
- Cadastro passa a tratar "episódios por temporada" como média ajustável
- Nova seção "Temporadas" na edição da série: adicionar, remover e redimensionar a quantidade de episódios de cada temporada